### PR TITLE
v1.3.0: simplify syntax using esnext and type module, update readme t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@
 
 Auto-generated Typescript type definitions for **Shopify Admin API**. Current version includes all types for version: `2020-04`.
 
+For other versions of the Shopify Admin API, use different branches of this package, as stated:
+- branch `2020-04` of this package uses version `2020-04` of the Shopify Admin API
+- branch `2021-04` of this package uses version `2021-04` of the Shopify Admin API
+
 If you're looking for typings for **Shopify Storefront Api**, checkout the [shopify-storefront-api-typings](https://www.npmjs.com/package/shopify-storefront-api-typings) package.
 
 ![types](https://user-images.githubusercontent.com/1438153/72280575-eb2ec200-3638-11ea-9609-4196400219f5.jpg)
 
 ## How to use
 
-1. Install package: `npm i -S shopify-admin-api-typings`
+1. Install package: `npm i -D shopify-admin-api-typings`, or, alternatively, specify a particular branch to use, e.g.: `npm i -D shopify-admin-api-typings#2021-04`.
 2. Import typings in your code. (vscode should find the typings and auto import for you).
 
 ```js
@@ -59,6 +63,17 @@ If you want to customise the namings or the Admin API version you can build your
 git clone https://github.com/caki0915/shopify-admin-api-typings.git
 ```
 
-2. Rename `.env.example` to `.env`.
+2. Copy `.env.example` to `.env`.
 3. Inside `.env` add your Shopify Admin API endpoint and access-token.
 4. Run `npm start`
+
+## Contribute your typings back to this repo as a new branch
+
+After building your own typings, feel free to contribute back to this repo:
+
+```shell
+% git checkout -b {your shopify Admin API version # here; e.g., 2021-04}
+% git add .
+% git commit -m "{your shopify Admin API version # here or whatever message; e.g. 2021-04}"
+% git push -u origin {your shopify Admin API version # here; e.g., 2021-04}
+```

--- a/generateSchema.js
+++ b/generateSchema.js
@@ -1,23 +1,14 @@
-const { GraphQLClient } = require("graphql-request");
-const { generateTypeScriptTypes } = require("graphql-schema-typescript");
-const { buildClientSchema } = require("graphql/utilities/buildClientSchema");
-const { introspectionQuery } = require("graphql/utilities/introspectionQuery");
-require("dotenv").config();
+import { GraphQLClient } from 'graphql-request';
+import { generateTypeScriptTypes } from 'graphql-schema-typescript';
+import { buildClientSchema, getIntrospectionQuery } from 'graphql';
+import { config } from 'dotenv';
 
-const graphQLClient = new GraphQLClient(process.env.ADMIN_ENDPOINT, {
+config();
+
+const data = await new GraphQLClient(process.env.ADMIN_ENDPOINT, {
   headers: {
-    "X-Shopify-Access-Token": process.env.ACCESS_TOKEN,
+    'X-Shopify-Access-Token': process.env.ACCESS_TOKEN,
   },
-});
-
-graphQLClient.request(introspectionQuery).then((data) => {
-  const build = buildClientSchema(data);
-  generateTypeScriptTypes(build, "./index.d.ts", { typePrefix: "" })
-    .then(() => {
-      process.exit(0);
-    })
-    .catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
-});
+}).request(getIntrospectionQuery());
+const build = buildClientSchema(data);
+await generateTypeScriptTypes(build, './index.d.ts', { typePrefix: '' });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "shopify-admin-api-typings",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Typings for Shopify Admin API",
+  "module": "esnext",
+  "type": "module",
   "author": {
     "name": "Carl-Johan Kihl",
     "email": "carljohan.kihl@gmail.com",
     "url": "https://carljohan.me"
   },
+  "contributors": [
+    "Carl-Johan Kihl",
+    "Riyad Shauk"
+  ],
   "repository": "github:caki0915/shopify-admin-api-typings",
   "bugs": {
     "url": "https://github.com/caki0915/shopify-admin-api-typings/issues"
@@ -19,12 +25,12 @@
   "main": "index.js",
   "types": "index.d.ts",
   "devDependencies": {
-    "dotenv": "8.2.0",
-    "graphql": "14.6.0",
-    "graphql-request": "1.8.2",
-    "graphql-schema-typescript": "1.3.2",
-    "lodash": "4.17.15",
-    "typescript": "3.9.3"
+    "dotenv": "10.0.0",
+    "graphql": "15.6.1",
+    "graphql-request": "3.5.0",
+    "graphql-schema-typescript": "1.5.2",
+    "lodash": "4.17.21",
+    "typescript": "4.4.3"
   },
   "peerDependencies": {
     "graphql": ">=14"


### PR DESCRIPTION
…o support multiple Shopify Admin API contributions

I've created a branch system for contributors to push different versions of the Shopify Admin API to those branches, whenever they run `npm start` on their own machine with their own `.env` file. This way, people don't need to do that manual process whenever a branch for the version of the API that they want to use exists. As explained in the README.

I also updated the JavaScript to use more modern syntax, and removed redundant code in the very concise/elegant file that you created to do this.